### PR TITLE
Update the design to the new 2026 design

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "SCDL SoundCloud Downloader",
-  "version": "5.4",
+  "version": "5.5",
 
   "description": "SoundCloud Download Helper. Adds ARTWORK, ARTIST, GENRE, TRACKNAME !!",
   "icons": {

--- a/scdler.js
+++ b/scdler.js
@@ -130,7 +130,7 @@ function insert_button() {
               if (elems[i].className.indexOf("sc-button-group-small") > -1) {
                 clone_a.className = "scdl_btn_start sc-button-download sc-button-secondary sc-button sc-button-small sc-button-icon sc-button-responsive";
                 clone_a.querySelector('.sc-button-label')?.classList.add('sc-visuallyhidden');
-                elems[i].appendChild(clone_a);
+                elems[i].insertBefore(clone_a, elems[i].lastElementChild);
               }else{
                 elems[i].appendChild(clone_a);
               }

--- a/scdler.js
+++ b/scdler.js
@@ -124,18 +124,16 @@ function insert_button() {
             console.log(kiddies[yts].className);
             if (kiddies[yts].className && kiddies[yts].className.indexOf("scdl_btn_start") < 0) {
               var clone_a = a_scdl.cloneNode(true);
-              if (elems[i].className.indexOf("sc-button-group-small") > -1) {
-                clone_a.className = "scdl_btn_start sc-button-download sc-button-secondary sc-button sc-button-small sc-button-icon sc-button-responsive";
-                var clone_labelSpan = clone_a.querySelector('.sc-button-label');
-                if (clone_labelSpan) {
-                  clone_labelSpan.classList.add('sc-visuallyhidden');
-                }
-              }else{
-              }
               clone_a.addEventListener("click", function() {
                 actual_listener_event(this);
               }, true);
-              elems[i].appendChild(clone_a);
+              if (elems[i].className.indexOf("sc-button-group-small") > -1) {
+                clone_a.className = "scdl_btn_start sc-button-download sc-button-secondary sc-button sc-button-small sc-button-icon sc-button-responsive";
+                clone_a.querySelector('.sc-button-label')?.classList.add('sc-visuallyhidden');
+                elems[i].appendChild(clone_a);
+              }else{
+                elems[i].appendChild(clone_a);
+              }
               yts = kiddies.length;
               scdl_elemets_that_have.push(elems[i].parentNode);
             } else {

--- a/scdler.js
+++ b/scdler.js
@@ -84,16 +84,19 @@ function putinadlin() {
 
 function insert_button() {
 
-  //var scdl_html_button = '<a class="scdl_btn_start sc-button sc-button-medium sc-button-responsive" tabindex="0" title="Download">&nbsp;&nbsp;&nbsp;&nbsp;SCDL</a>';
-
-
-  var a_scdl = document.createElement('a');
-  var linkText = document.createTextNode(" . . SCDL");
-  a_scdl.appendChild(linkText);
+  var a_scdl = document.createElement('button');
   a_scdl.title = "Download";
-  //a_scdl.href = "#";
-  a_scdl.className = "scdl_btn_start sc-button sc-button-small sc-button-responsive";
+  a_scdl.setAttribute('aria-label', 'Download this track');
+  a_scdl.className = "scdl_btn_start sc-button-download sc-button-secondary sc-button sc-button-medium sc-button-responsive";
 
+  var iconDiv = document.createElement('div');
+  iconDiv.innerHTML = '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8 15A7 7 0 108 1a7 7 0 000 14zm3.47-7.53l1.06 1.06L8 13.06 3.47 8.53l1.06-1.06 2.72 2.72V3h1.5v7.19l2.72-2.72z" fill="currentColor"></path></svg>';
+  a_scdl.appendChild(iconDiv);
+
+  var labelSpan = document.createElement('span');
+  labelSpan.className = "sc-button-label";
+  labelSpan.textContent = "SCDL";
+  a_scdl.appendChild(labelSpan);
 
   var elems = document.getElementsByTagName('*'),
     i;
@@ -121,6 +124,14 @@ function insert_button() {
             console.log(kiddies[yts].className);
             if (kiddies[yts].className && kiddies[yts].className.indexOf("scdl_btn_start") < 0) {
               var clone_a = a_scdl.cloneNode(true);
+              if (elems[i].className.indexOf("sc-button-group-small") > -1) {
+                clone_a.className = "scdl_btn_start sc-button-download sc-button-secondary sc-button sc-button-small sc-button-icon sc-button-responsive";
+                var clone_labelSpan = clone_a.querySelector('.sc-button-label');
+                if (clone_labelSpan) {
+                  clone_labelSpan.classList.add('sc-visuallyhidden');
+                }
+              }else{
+              }
               clone_a.addEventListener("click", function() {
                 actual_listener_event(this);
               }, true);

--- a/styler.css
+++ b/styler.css
@@ -22,19 +22,3 @@
     /*width:77px;
 	text-align:center;*/
 }
-
-.scdl_btn_start:before {
-    left: 5px;
-    content: "";
-    display: block;
-    position: absolute;
-    background-repeat: no-repeat;
-    background-position: center center;
-    width: 20px;
-    height: 20px;
-    top: 0;
-    bottom: 0;
-    margin: auto 0;
-    background-size: 16px 16px;
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+UmVjdGFuZ2xlIDMxPC90aXRsZT48ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz48cGF0aCBkPSJNMyAxMXYyaDEwdi0yaC0xMHptMC03aDEwbC01IDYtNS02em0zLTJ2Mmg0di0yaC00eiIgZmlsbD0iIzIyMiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9zdmc+);
-}


### PR DESCRIPTION
This makes the buttons visually the same as the ones from the new design, also utilizing the original download icon from soundcloud
I've modified it from a `<a>` tag to a `<button>` to make it more aligned with the other elements
It also respects the "`sc-button-group-small`" variant that is seen in playlists
<img width="1106" height="319" alt="image" src="https://github.com/user-attachments/assets/d274d2cc-76db-4c5e-9d5b-52340f19d081" />
<img width="848" height="392" alt="image" src="https://github.com/user-attachments/assets/f90a7e56-14a9-405e-8412-6b72e084246f" />
